### PR TITLE
--verbose: print messages on screen as well as into log files

### DIFF
--- a/everest
+++ b/everest
@@ -40,6 +40,12 @@ make_non_interactive () {
   export GIT_TERMINAL_PROMPT=0
 }
 
+# Verbosity may still be enabled while logging
+VERBOSE=false
+make_verbose () {
+  VERBOSE=true
+}
+
 # The whole script makes the assumption that we're in the everest directory;
 # this is a conservative method that ensures we switch to this directory first
 # thing. Basically, this supports:
@@ -630,7 +636,7 @@ print_usage ()
   cat <<HELP
 OVERVIEW: $0, a high-level management script for Project Everest
 
-USAGE: $0 [--yes] COMMANDS
+USAGE: $0 [--yes] [--verbose] COMMANDS
 
 COMMAND:
   check     ensure that all the required programs are found in path, install
@@ -665,6 +671,10 @@ while true; do
   case "$1" in
     --yes)
       make_non_interactive
+      ;;
+
+    --verbose)
+      make_verbose
       ;;
 
     check)

--- a/lib.sh
+++ b/lib.sh
@@ -31,13 +31,13 @@ count () {
   i=0
   echo -n > $1
   while read line; do
-    echo "$line" >> $1
-    if $VERBOSE ; then
-	echo "$line"
-    else
+   echo "$line" >> $1
+   if $VERBOSE ; then
+    echo "$line"
+   else
     i=$(($i+1))
     echo -ne "\r$i lines of output"
-    fi
+   fi
   done
   echo
   blue "log written to $1"

--- a/lib.sh
+++ b/lib.sh
@@ -31,9 +31,13 @@ count () {
   i=0
   echo -n > $1
   while read line; do
-    echo $line >> $1
+    echo "$line" >> $1
+    if $VERBOSE ; then
+	echo "$line"
+    else
     i=$(($i+1))
     echo -ne "\r$i lines of output"
+    fi
   done
   echo
   blue "log written to $1"


### PR DESCRIPTION
It might be useful to have messages printed on screen while testing AND have logs generated as well, which this pull request proposes.

We should document somewhere that --verbose has no effect if --yes is already given: --verbose adds printing messages on screen only if logging is enabled, whereas --yes prints everything on screen anyway.
