### PR TITLE
Fix up .gitignore, add commands "merge" and "forall" to everest script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,11 @@ log
 
 test/_build
 test/test.native
+
+flexdll/
+nuget/
+setup.log
+setup.log.full
+z3-4.5.0-x64-win/
+*.zip
+.repo

--- a/everest
+++ b/everest
@@ -572,7 +572,7 @@ declare -a remaining_args
 
 self_update () {
   old_revision=$(git rev-parse HEAD)
-  git pull
+  git pull --rebase
   if [[ $(git rev-parse HEAD) != $old_revision ]]; then
     blue "Self-updating to new everest revision $(git rev-parse HEAD | cut -c 1-8)"
     # Now, we transfer execution to the new version of $0
@@ -644,6 +644,34 @@ do_reset ()
     cd ..
   done
 }
+
+do_merge ()
+{
+  self_update
+  echo Merging working copies
+  for r in ${!repositories[@]}; do
+    echo
+    blue "Pulling and rebasing $r"
+    cd $r
+    git pull --rebase
+    cd ..
+  done
+}
+
+do_push ()
+{
+  blue Pushing toplevel
+  git push
+  for r in ${!repositories[@]}; do
+    echo
+    blue "Pushing $r"
+    cd $r
+    git push
+    cd ..
+  done
+}
+
+
 
 run_nuget () {
   # This function is called in a subshell in a test context (via possibly_log)
@@ -917,6 +945,10 @@ COMMAND:
   pull      self-update the everest repository (i.e. the script and
             hashes.sh) then run reset
 
+  merge     pull all projects, merging and rebasing local changes
+
+  push      push changes in all directories to upstream
+
   reset     pull all projects and move them to the revisions specified by
             hashes.sh
 
@@ -966,6 +998,17 @@ while true; do
       # new version of $0
       remaining_args=("$@")
       do_pull
+      ;;
+
+    merge)
+      # Save the remaining options (including pull) for calling the
+      # new version of $0
+      remaining_args=("$@")
+      do_merge
+      ;;
+
+    push)
+      do_push
       ;;
 
     reset)

--- a/everest
+++ b/everest
@@ -671,8 +671,6 @@ do_push ()
   done
 }
 
-
-
 run_nuget () {
   # This function is called in a subshell in a test context (via possibly_log)
   # which means that -e is not inherited. Explicit failures here.

--- a/everest
+++ b/everest
@@ -660,7 +660,7 @@ do_merge ()
 
 do_forall ()
 {
-  blue Executing on toplevel
+  blue "Executing on toplevel"
   "${remaining_args[@]}"
   for r in ${!repositories[@]}; do
     echo
@@ -1010,6 +1010,7 @@ while true; do
       shift
       remaining_args=("$@")
       do_forall
+      break
       ;;
 
     reset)

--- a/everest
+++ b/everest
@@ -658,15 +658,15 @@ do_merge ()
   done
 }
 
-do_push ()
+do_forall ()
 {
-  blue Pushing toplevel
-  git push
+  blue Executing on toplevel
+  "${remaining_args[@]}"
   for r in ${!repositories[@]}; do
     echo
-    blue "Pushing $r"
+    blue "Executing in $r"
     cd $r
-    git push
+    ${remaining_args[@]}
     cd ..
   done
 }
@@ -943,9 +943,10 @@ COMMAND:
   pull      self-update the everest repository (i.e. the script and
             hashes.sh) then run reset
 
-  merge     pull all projects, merging and rebasing local changes
+  merge     pull all projects, merging and rebasing local changes; does NOT
+            reset to known to be good version, but preserves your changes
 
-  push      push changes in all directories to upstream
+  forall    execute command in all git repository directories
 
   reset     pull all projects and move them to the revisions specified by
             hashes.sh
@@ -1005,8 +1006,10 @@ while true; do
       do_merge
       ;;
 
-    push)
-      do_push
+    forall)
+      shift
+      remaining_args=("$@")
+      do_forall
       ;;
 
     reset)


### PR DESCRIPTION
These commands are there to make life with multiple git repositories a little easier. "forall" is a copy of the command of the same name from the repo tool used in Android: it simply executes a given command in all repositories. "merge" issues a "git pull --rebase" in all repositories, it only exists as a special command because it will re-start the everest script after update, the way "pull" does.