### PR TITLE
Look for ctypes.foreign.unthreaded package instead of ctypes.foreign - fixes #56

### DIFF
--- a/opam-packages
+++ b/opam-packages
@@ -14,4 +14,4 @@ sedlex sedlex
 ctypes ctypes
 ulex ulex
 visitors visitors
-ctypes.foreign ctypes-foreign
+ctypes.foreign.unthreaded ctypes-foreign


### PR DESCRIPTION
This is what I've attempted after I did the above:

1. opam uninstall ctypes-foreign
2. ./everest check
3. ./everest make

Now I get that same error about ctypes.foreign.threaded not being found. So then:

4. Change the last line in opam-packages to: ctypes.foreign.unthreaded ctypes-foreign
5. ./everest check (This step notices the package is not installed and asks me to run install_all_opam_packages, for which I tell it yes, and then asks me to approve installing ctypes-foreign.)
6. ./everest make

Now the build succeeds.