### PR TITLE
Fix #64 (kermlin test failing due to bad OpenSSL)

### DIFF
--- a/everest
+++ b/everest
@@ -1060,7 +1060,7 @@ do_test () {
   blue "Running tests (commands shown below)"
   set -x
   # kremlin
-  make -C kremlin/test $parallel_opt everything
+  LD_LIBRARY_PATH= make -C kremlin/test $parallel_opt everything
   # evercrypt
   make -C hacl-star test $parallel_opt
   # qd


### PR DESCRIPTION
Make kremlin test use system OpenSSL