### PR TITLE
forall: continue on errors

### DIFF
--- a/everest
+++ b/everest
@@ -914,7 +914,7 @@ do_forall ()
   for r in ${!repositories[@]}; do
     echo
     blue "Executing in $r"
-    (cd $r && "$@" || true)
+    (cd $r && "$@" || red "return code was $?, carrying on anyway")
   done
 }
 

--- a/everest
+++ b/everest
@@ -914,9 +914,7 @@ do_forall ()
   for r in ${!repositories[@]}; do
     echo
     blue "Executing in $r"
-    cd $r
-    "$@"
-    cd ..
+    (cd $r && "$@" || true)
   done
 }
 


### PR DESCRIPTION
Mostly motivated by `./everest forall git grep blah`. If one of the
greps comes out empty, it also has a non-zero exit code and the script
will not run the command on the remaining repos (since we have -e). The
same happens when git invokes a pager (less) and one presses 'q' to
quit.

While at it use a subshell instead of cd-ing back to the parent
directory.