### PR TITLE
introduce 'everest advance'

### DIFF
--- a/everest
+++ b/everest
@@ -38,6 +38,8 @@ SED=$(which gsed >/dev/null 2>&1 && echo gsed || echo sed)
 # non-interactive mode
 OPAM_AUTO_SETUP=
 
+ADVANCE_YES=false
+
 # No-interaction when this script is used for CI purposes
 INTERACTIVE=true
 make_non_interactive () {
@@ -46,6 +48,7 @@ make_non_interactive () {
   export GIT_TERMINAL_PROMPT=0
   export OPAMYES=1
   export NOSHORTLOG=1
+  export ADVANCE_YES=true
   OPAM_AUTO_SETUP=--auto-setup
 }
 
@@ -910,6 +913,11 @@ do_advance ()
     pushd $r
     branch=${branches[$r]}
 
+    if ( ! $ADVANCE_YES ) && ( git status -s -uall | grep -q . ); then
+        red "project $r has local changes, aborting advance (pass --yes to ignore)"
+        exit 1
+    fi
+
     git checkout -f $branch
     git fetch
     git reset --hard origin/$branch
@@ -1318,7 +1326,7 @@ COMMAND:
   pull      self-update the everest repository (i.e. the script and
             hashes.sh) then run reset
 
-  advance   advance every subproject by pulling from their tracked branches
+  advance   advance every project by pulling from their tracked branches
 
   get_vale  install the right version of vale binary (implied by pull)
 

--- a/everest
+++ b/everest
@@ -836,25 +836,31 @@ do_pull () {
   do_reset
 }
 
+symlink_clone_warned=false
+
+check_subp_exists () {
+  local r=$1
+  if [ ! -d $r ]; then
+    if [ -e $r ]; then
+      red "$r exists but is not a directory, aborting"
+      exit 1
+    fi
+    if ! $symlink_clone_warned; then
+      echo Note: you\'re welcome to create symbolic links if you already have \
+        cloned the repository elsewhere
+      symlink_clone_warned=true
+    fi
+    try_git_clone ${repositories[$r]} ${https[$r]} $r
+  fi
+}
+
 do_reset ()
 {
-  warned=false
   for r in $ALL_PROJECTS; do
     echo
     blue "Pulling $r"
     # Some sanity checks, and clone the repositories that aren't there already
-    if [ ! -d $r ]; then
-      if [ -e $r ]; then
-        red "$r exists but is not a directory, aborting"
-        exit 1
-      fi
-      if ! $warned; then
-        echo Note: you\'re welcome to create symbolic links if you already have \
-          cloned the repository elsewhere
-        warned=true
-      fi
-      try_git_clone ${repositories[$r]} ${https[$r]} $r
-    fi
+    check_subp_exists "$r"
 
     # Note: the snapshot command guarantees that the commit was pushed to a
     # branch of the form origin/foo. So, we checkout foo, because there's a good
@@ -892,6 +898,24 @@ do_reset ()
     cd ..
   done
   get_vale
+}
+
+do_advance ()
+{
+  for r in $ALL_PROJECTS; do
+    echo
+    blue "Advancing $r"
+    check_subp_exists "$r"
+
+    pushd $r
+    branch=${branches[$r]}
+
+    git checkout -f $branch
+    git fetch
+    git reset --hard origin/$branch
+    git submodule update --init
+    popd
+  done
 }
 
 do_merge ()
@@ -1294,6 +1318,8 @@ COMMAND:
   pull      self-update the everest repository (i.e. the script and
             hashes.sh) then run reset
 
+  advance   advance every subproject by pulling from their tracked branches
+
   get_vale  install the right version of vale binary (implied by pull)
 
   merge     pull all projects, merging and rebasing local changes; does NOT
@@ -1408,6 +1434,10 @@ while true; do
 
     pull_projects)
       do_pull
+      ;;
+
+    advance)
+      do_advance
       ;;
 
     pull_vale)

--- a/everest
+++ b/everest
@@ -1203,7 +1203,7 @@ do_snapshot ()
   blue "Recording a new snapshot"
   echo "declare -A hashes" > new-hashes.sh
   echo "declare -A branches" >> new-hashes.sh
-  for r in $(echo ${!repositories[@]} | tr ' ' '\n' | sort) ; do
+  for r in $(echo ${!repositories[@]} | tr ' ' '\n' | sort -f) ; do
     cd $r
     head=$(git rev-parse HEAD)
     branch=$(git symbolic-ref HEAD)


### PR DESCRIPTION
Does something like this already exists? It's a shortcut to updating every, or the named subprojects to master.

Would need a few tweaks before merging, but curious how the CI machine does this? Have I just missed the relevant command?

Here's an example of advancing F*:
```
./everest FStar advance
# Switching to the everest directory ... now in /home/guido/r/everest


Advancing FStar
~/r/everest/FStar ~/r/everest
Already on 'master'
Your branch is behind 'origin/master' by 10 commits, and can be fast-forwarded.
  (use "git pull" to update your local branch)
HEAD is now at 15fe9e9322 Merge branch 'master' of github:FStarLang/FStar
~/r/everest
```

I suppose it's similar to `./everest forall git pull`?