### PR TITLE
introduce `everest archive`

### DIFF
--- a/everest
+++ b/everest
@@ -41,6 +41,7 @@ OPAM_AUTO_SETUP=
 ADVANCE_YES=false
 
 IS_ARCHIVE=false
+VALE_ARCHIVE=true
 
 # No-interaction when this script is used for CI purposes
 INTERACTIVE=true
@@ -984,8 +985,10 @@ do_archive ()
   done
 
   # Copy vale
-  cp -r vale/ ${OUTDIR}/vale
-  rm ${OUTDIR}/vale/vale-release.zip # Not needed, save some space
+  if $VALE_ARCHIVE; then
+    cp -r vale/ ${OUTDIR}/vale
+    rm ${OUTDIR}/vale/vale-release.zip # Not needed, save some space
+  fi
 
   # Remove unneded (and large) files from the staging directory.
   rm ${OUTDIR}/FStar/src/VS/.nuget/NuGet.exe
@@ -1473,7 +1476,9 @@ COMMAND:
 
   archive   create an xzipped tarball with all the Everest sources; the
             archive can be built without an internet connection and is
-            meant to be small in size (so it does not include Git history)
+            meant to be small in size (so it does not include Git history);
+            you can use the --no-vale-archive to exclude vale binaries and
+            obtain a smaller archive
 
   clean-c   only clean generated C files, useful when switching to -windows
 
@@ -1484,7 +1489,7 @@ HELP
 }
 
 OPTIONS=j:k
-LONGOPTS=yes,windows,openssl,opt,admit
+LONGOPTS=yes,windows,openssl,opt,admit,no-vale-archive
 
 # Temporarily stores output to check for errors
 # --alternative allows long options to start with a single '-'
@@ -1515,11 +1520,6 @@ while true; do
             shift
             ;;
 
-        --admit)
-            export OTHERFLAGS="$OTHERFLAGS --admit_smt_queries true"
-            shift
-            ;;
-
         -windows|--windows)
             set_windows
             shift
@@ -1532,6 +1532,16 @@ while true; do
 
         -opt|--opt)
             set_opt
+            shift
+            ;;
+
+        -admit|--admit)
+            export OTHERFLAGS="$OTHERFLAGS --admit_smt_queries true"
+            shift
+            ;;
+
+        -no-vale-archive|--no-vale-archive)
+            VALE_ARCHIVE=false
             shift
             ;;
 

--- a/everest
+++ b/everest
@@ -939,6 +939,53 @@ do_advance ()
   done
 }
 
+do_archive ()
+{
+  TEMPDIR=$(mktemp -d -p .)
+  OUTDIR0=${TEMPDIR}/everest/
+  OUTDIR=$(realpath ${OUTDIR0})
+
+  # Make sure every subproject is there.
+  for r in ${!repositories[@]}; do
+    check_subp_exists "$r"
+  done
+
+  # Now we're sure hacl-star is there, so we have
+  # hacl-star/vale/.vale_version. Fetch that version of vale.
+  get_vale
+
+  # Go through each sub-repository (including the openssl submodule for MLCrypto)
+  # and put them in the staging directory ${OUTDIR}
+  mkdir -p ${OUTDIR}
+  for r in ${!repositories[@]} MLCrypto/openssl/; do
+    echo
+    blue "Archiving $r"
+
+    pushd $r
+      if ( git status -s -uall | grep -q . ); then
+          red "WARNING: project $r has local changes which will not be reflected in the archive"
+      fi
+      git archive HEAD --prefix "$r/" | tar -C ${OUTDIR} -x
+    popd
+  done
+
+  cp -r vale/ ${OUTDIR}/vale
+  rm ${OUTDIR}/vale/vale-release.zip # Not needed, save some space
+
+  cp everest \
+     hashes.sh \
+     repositories.sh \
+     lib.sh \
+     LICENSE \
+     README.md \
+       ${OUTDIR}
+
+  rm -f everest_archive.tar{,.xz} # Clean old files if any
+  tar -C ${TEMPDIR} --strip-components=1 -c -f everest_archive.tar everest/
+  rm -r ${TEMPDIR}
+  xz -9 everest_archive.tar
+}
+
 do_merge ()
 {
   self_update
@@ -1398,6 +1445,10 @@ COMMAND:
 
   qbuild    build Windows libraries using Visual Studio
 
+  archive   create an xzipped tarball with all the Everest sources; the
+            archive can be built without an internet connection and is
+            meant to be small in size (so it does not include Git history)
+
   clean-c   only clean generated C files, useful when switching to -windows
 
   clean     clean all projects
@@ -1566,6 +1617,10 @@ while true; do
 
     qbuild)
       do_qbuild
+      ;;
+
+    archive)
+      do_archive
       ;;
 
     *)

--- a/everest
+++ b/everest
@@ -996,6 +996,7 @@ do_archive ()
   rm -r ${OUTDIR}/mitls-fstar/tests/
 
   cp everest \
+     opam-packages \
      hashes.sh \
      repositories.sh \
      lib.sh \

--- a/everest
+++ b/everest
@@ -40,6 +40,8 @@ OPAM_AUTO_SETUP=
 
 ADVANCE_YES=false
 
+IS_ARCHIVE=false
+
 # No-interaction when this script is used for CI purposes
 INTERACTIVE=true
 make_non_interactive () {
@@ -104,6 +106,16 @@ cd_to_everest () {
 # the new version of $0
 initial_pwd="$(pwd)"
 cd_to_everest
+
+check_no_archive () {
+  if $IS_ARCHIVE; then
+    red "This is an archived Everest repo, and the command you attempted to run \
+         is not supported."
+    red "To proceed anyway *at your own risk*, set the IS_ARCHIVE variable to \
+         false within this script and re-run."
+    exit 1
+  fi
+}
 
 # "Modularity": include other files (requires us to be in the right directory)
 source lib.sh
@@ -833,6 +845,7 @@ get_vale ()
 }
 
 self_update () {
+  check_no_archive
   old_revision=$(git rev-parse HEAD)
   git pull --rebase
   if [[ $(git rev-parse HEAD) != $old_revision ]]; then
@@ -855,6 +868,7 @@ do_pull () {
 symlink_clone_warned=false
 
 check_subp_exists () {
+  check_no_archive
   local r=$1
   if [ ! -d $r ]; then
     if [ -e $r ]; then
@@ -985,6 +999,8 @@ do_archive ()
      LICENSE \
      README.md \
        ${OUTDIR}
+
+  $SED -i 's/^IS_ARCHIVE=.*/IS_ARCHIVE=true/' ${OUTDIR}/everest
 
   rm -f everest_archive.tar{,.xz} # Clean old files if any
   tar -C ${TEMPDIR} -c -f everest_archive.tar everest/
@@ -1204,6 +1220,7 @@ do_make ()
 }
 
 do_test () {
+  check_no_archive
   setup_env
 
   separator
@@ -1308,6 +1325,7 @@ MSG
 
 do_drop ()
 {
+  check_no_archive
   setup_env
 
   blue "Dropping sources for Windows libraries"
@@ -1316,6 +1334,7 @@ do_drop ()
 
 do_qbuild ()
 {
+  check_no_archive
   setup_env
 
   blue "Building Windows libraries"

--- a/everest
+++ b/everest
@@ -969,8 +969,14 @@ do_archive ()
     popd
   done
 
+  # Copy vale
   cp -r vale/ ${OUTDIR}/vale
   rm ${OUTDIR}/vale/vale-release.zip # Not needed, save some space
+
+  # Remove unneded (and large) files from the staging directory.
+  rm ${OUTDIR}/FStar/src/VS/.nuget/NuGet.exe
+  rm -r ${OUTDIR}/MLCrypto/openssl/fuzz/corpora/
+  rm -r ${OUTDIR}/mitls-fstar/tests/
 
   cp everest \
      hashes.sh \
@@ -981,9 +987,10 @@ do_archive ()
        ${OUTDIR}
 
   rm -f everest_archive.tar{,.xz} # Clean old files if any
-  tar -C ${TEMPDIR} --strip-components=1 -c -f everest_archive.tar everest/
+  tar -C ${TEMPDIR} -c -f everest_archive.tar everest/
   rm -r ${TEMPDIR}
-  xz -9 everest_archive.tar
+  blue "Compressing archive..."
+  xz --extreme -9 everest_archive.tar
 }
 
 do_merge ()


### PR DESCRIPTION
This PR introduces an `archive` subcommand to generate a compressed tarball with all the relevant sources for building (and checking) Everest. After extracting the tarball, hitting `make` will build all of Everest without needing an external connection--- not even for fetching vale, but working OCaml and z3 installs are required. The archive does not include any Git history, which is what saves the most space, nor any Git repos at all.

This is useful if one of us needs to reproduce a build failure and has a very poor connection (for whatever reason :-) ). The compressed archive is currently 25MB, while all of the Everest *repos* together take up 2GB. All the sources are about 248MB, so the compression factor is about 10x. The vale binaries, which seldom change, take up about 2MB of the final compressed size of 25MB.

I ran `./everest make` on an extracted archive and got a green. Most other commands do not work since they require repos.

Some possible improvements

1- Do create Git repos in the archive, but without any history. 
2- Add a flag to skip vale
3- Allow to choose compressor and compression levels?
4- Tweak the `everest` script in the archive so it can check that it's running on archived sources, and fail gracefully.


Commit message below

---

Creates an archive of the everest script along with sources of all
subprojects, without any git history, which is enough to build
everything from scratch via `./everest make`.