### PR TITLE
config file should be .profile if .bash_profile does not exist

### DIFF
--- a/everest
+++ b/everest
@@ -75,9 +75,16 @@ set_make_opts () {
 }
 
 # The file where to store customized environment variables
-# (default is $HOME/.bash_profile)
 if [[ $EVEREST_ENV_DEST_FILE == "" ]] ; then
-  EVEREST_ENV_DEST_FILE="$HOME/.bash_profile"
+  # For people who have installed and initialized opam prior to
+  # running ./everest check, opam will modify .profile instead of
+  # .bash_profile, if the latter does not exist. So we need to
+  # account for that case.
+  if [[ -f "$HOME/.bash_profile" ]] ; then
+      EVEREST_ENV_DEST_FILE="$HOME/.bash_profile"
+  else
+      EVEREST_ENV_DEST_FILE="$HOME/.profile"
+  fi
 fi
 
 # The whole script makes the assumption that we're in the everest directory;


### PR DESCRIPTION
I tried to compile Everest on a fresh Ubuntu 18.04 LTS machine, by manually installing and initializing `opam` before running `./everest check`.
It turns out that, on such a fresh machine, `.bash_profile` initially does not exist, so `opam init` modifies `.profile` instead.
But then, `./everest` creates and modifies `.bash_profile`, which results in bash skipping `.profile`  at the next login; thus, the opam environment is no longer properly set.
To solve this issue, I make `./everest` modify `.profile` by default if `.bash_profile` does not exist.

Context: I am trying to write detailed instructions to compile EverParse on Linux, and I believe that asking the user to manually set `EVEREST_ENV_DEST_FILE` to account for this case is not user-friendly. We recently received feedback from a new user trying to compile EverParse on Ubuntu 18.04 LTS because they could not run our binary package, which works only with Ubuntu 20.04 because of glibc (that has been corrected since, and we reuploaded a binary package built on Ubuntu 18.04 instead), and they failed because of that issue.