### PR TITLE
Indicate in help which commands can be restricted

### DIFF
--- a/everest
+++ b/everest
@@ -1449,7 +1449,9 @@ OPTION:
   -openssl  Use OpenSSL for AEAD in miTLS
 
 PROJECT:
-  restrict the subsequent commands to operate on one of the following:
+  The commands
+    pull reset advance merge make
+  can be restricted to operate on one of the following:
     FStar karamel mitls-fstar hacl-star MLCrypto everparse
 
 COMMAND:


### PR DESCRIPTION
Yesterday I accidentally cleaned my entire build because `clean` is not using the project restriction. So I thought I improve the `help` text a bit. I tried to understand the best I could which commands take the restriction.