### PR TITLE
Remove SCons logic

### DIFF
--- a/.docker/build/linux/Dockerfile.everest-move
+++ b/.docker/build/linux/Dockerfile.everest-move
@@ -8,7 +8,7 @@ FROM ocaml/opam:ubuntu-ocaml-$OCAML_VERSION
 # Install the dependencies of Project Everest
 ENV DEBIAN_FRONTEND=noninteractive
 RUN sudo apt-get update
-RUN sudo apt-get --yes install --no-install-recommends m4 time gnupg ca-certificates python-is-python3 python3 nodejs cmake wget scons python2.7
+RUN sudo apt-get --yes install --no-install-recommends m4 time gnupg ca-certificates python-is-python3 python3 nodejs cmake wget python2.7
 
 # Install .NET Core, following https://docs.microsoft.com/en-us/dotnet/core/install/linux-ubuntu
 RUN sudo apt install -y gnupg ca-certificates wget && \

--- a/README.md
+++ b/README.md
@@ -29,10 +29,6 @@ If you don't have Opam for Windows installed already, please download and run
 the [64-bit installer](https://fdopen.github.io/opam-repository-mingw/installation/).
 It will also install Cygwin, then you can launch this script from a Cygwin prompt.
 
-Install the [production scons for
-Windows](http://scons.org/pages/download.html). After installation, ensure that
-`scons.bat` is in the system path.
-
 ## Usage
 
 See `./everest help`

--- a/everest
+++ b/everest
@@ -16,19 +16,7 @@ set -o pipefail
 OPAM_URL=https://github.com/fdopen/opam-repository-mingw/releases/download/0.0.0.2/opam64.tar.xz
 MINIMAL_OCAML_VERSION=4.08.0
 OPAM_VERSION=4.12.0+mingw64c
-# Provide for a Python, necessary for scons
-# (all other occurrences of python can use whatever python 2 is in the PATH, be it Windows or Cygwin)
-# NOTE: if you change SCONS_PYTHON_MAJOR and/or SCONS_PYTHON_MINOR, then please also update scons-python-version-test.py
-SCONS_PYTHON_MAJOR=3
-SCONS_PYTHON_MINOR=6
-SCONS_PYTHON_MAJOR_MINOR=$SCONS_PYTHON_MAJOR.$SCONS_PYTHON_MINOR
-SCONS_PYTHON_REVISION=6
-SCONS_PYTHON_VER=$SCONS_PYTHON_MAJOR_MINOR.$SCONS_PYTHON_REVISION
-# NOTE: if you change SCONS_VER, then please also update scons-python-version-test.py
-SCONS_VER=3.0.1
-SCONS_INSTALL_DIR=scons-$SCONS_VER
-SCONS_INSTALL_FILE=$SCONS_INSTALL_DIR.tar.gz
-SCONS_INSTALL_POINT=https://downloads.sourceforge.net/project/scons/scons/$SCONS_VER/$SCONS_INSTALL_FILE
+
 SED=$(which gsed >/dev/null 2>&1 && echo gsed || echo sed)
 MAKE=$(which gmake >/dev/null 2>&1 && echo gmake || echo make)
 
@@ -223,7 +211,6 @@ windows_append_path () {
 # customize "$EVEREST_ENV_DEST_FILE"
 #   $1: name of command to check for
 #   $2: candidate directory where it may reside
-# NOTE: this function is also used to locate python and scons
 windows_check_or_modify_env_dest_file () {
   if ! command -v $1 >/dev/null 2>&1; then
     red "ERROR: $1 not found in PATH"
@@ -265,19 +252,6 @@ write_cxx_env_dest_file () {
   str="
     # This line automatically added by $0
     export CXX=x86_64-w64-mingw32-g++.exe"
-  write_to_env_dest_file "$str"
-}
-
-write_everest_env_dest_file () {
-  if is_windows; then
-    str="
-    # These lines automatically added by $0
-    export EVEREST_SCONS_CACHE_DIR=$(cygpath -m \"$TEMP\"/everest)"
-  else
-    str="
-    # These lines automatically added by $0
-    export EVEREST_SCONS_CACHE_DIR=/tmp/everest"
-  fi
   write_to_env_dest_file "$str"
 }
 
@@ -397,87 +371,6 @@ do_update_z3 () {
     prompt_yes "write_z3_env_dest_file $new_z3_folder" true
     rm -f z3
     ln -sf $new_z3_folder z3
-  fi
-}
-
-# Windows-only: print out the directory of the Python associated to SCons
-windows_scons_python_dir () {
-    PYDIR=$(regtool -q get "/HKLM/Software/Python/PythonCore/$SCONS_PYTHON_MAJOR_MINOR/InstallPath/" || true)
-    if ! [[ -d $PYDIR ]] ; then
-      PYDIR=$(regtool -q get "/HKCU/Software/Python/PythonCore/$SCONS_PYTHON_MAJOR_MINOR/InstallPath/" || true)
-    fi
-    if ! [[ -d $PYDIR ]] ; then
-      red "ERROR: Python $SCONS_PYTHON_MAJOR_MINOR was not installed properly"
-      exit 1
-    fi
-    echo "$PYDIR"
-}
-
-# check_windows_scons: (Windows only) checks if Python 3.x and a
-# corresponding Scons and pywin32 are installed; and if not, propose
-# to install scons and pywin32 along with its required Python
-check_windows_scons ()
-{
-  if command -v scons.bat > /dev/null 2>&1 ; then
-    echo "... scons.bat found in PATH"
-    # Check whether it corresponds to the right expected version of Python
-    scons.bat --file=scons-python-version-test.py
-    echo "... scons is well configured for Python $SCONS_PYTHON_MAJOR_MINOR"
-  else
-    magenta "Warning: scons.bat not found in PATH"
-    if ! PYDIR=$(windows_scons_python_dir) ; then
-      red "ERROR: No Python $SCONS_PYTHON_MAJOR_MINOR found"
-      magenta "Do you want to install Windows Python $SCONS_PYTHON_VER , and scons for that version of Python?"
-      prompt_yes true "exit 1"
-      local python_file_name="python-$SCONS_PYTHON_VER-amd64.exe"
-      wget "https://www.python.org/ftp/python/$SCONS_PYTHON_VER/$python_file_name"
-      chmod +x "$python_file_name"
-      # From: https://docs.python.org/3/using/windows.html
-      "./$python_file_name" /passive
-      PYDIR=$(windows_scons_python_dir)
-    else
-      echo "... Python $SCONS_PYTHON_MAJOR_MINOR found"
-    fi
-    if "$PYDIR/python.exe" "$PYDIR/Scripts/scons.py" -f scons-python-version-test.py ; then
-      echo '... SCons for Python $SCONS_PYTHON_MAJOR_MINOR was detected'
-    else
-      red "No SCons detected for Python $SCONS_PYTHON_MAJOR_MINOR"
-      magenta "Do you want to install SCons $SCONS_VER for Python $SCONS_PYTHON_MAJOR_MINOR ?"
-      prompt_yes true "exit 1"
-      wget $SCONS_INSTALL_POINT
-      tar xf "$SCONS_INSTALL_FILE"
-      pushd "$SCONS_INSTALL_DIR"
-      "$PYDIR/python.exe" setup.py install # --prefix=$scons_target_wdir
-      popd
-      # Test whether SCons was installed properly
-      "$PYDIR/python.exe" "$PYDIR/Scripts/scons.py" -f scons-python-version-test.py
-    fi
-    magenta 'The default scons.bat is installed in a directory that cannot be added to PATH,'
-    magenta 'because that directory contains a python.exe, which would shadow the already'
-    magenta 'existing python command that shall point to a Python 2.x.'
-    magenta 'Do you want to create a new scons.bat and have PATH point to it?'
-    if prompt_yes true false
-    then
-      pydir_dos=$(cygpath -d "$PYDIR")
-      mkdir -p scons
-      echo "$pydir_dos/python.exe $pydir_dos/Scripts/scons.py "'%*' > scons/scons.bat
-      chmod +x scons/scons.bat
-      windows_append_path "$PWD/scons"
-    fi
-  fi
-  # Also test for pywin32
-  echo "checking for pywin32"
-  if ! PYDIR=$(windows_scons_python_dir) ; then
-    red "ERROR: Python $SCONS_PYTHON_MAJOR_MINOR was not installed properly"
-    exit 1
-  fi
-  if "$PYDIR/Scripts/pip.exe" show pywin32 ; then
-    echo "... pywin32 found"
-  else
-    red "pywin32 does not seem to be installed for Python $SCONS_PYTHON_MAJOR_MINOR"
-    magenta "Do you want to install it?"
-    prompt_yes true "exit 1"
-    "$PYDIR/Scripts/pip.exe" install pywin32
   fi
 }
 
@@ -787,32 +680,6 @@ OCAML
     echo "... python2 found in PATH"
   fi
 
-  # We need Scons for Vale which needs Python 3
-  if is_windows; then
-    check_windows_scons
-  else # *nix
-    if ! command -v scons >/dev/null 2>&1; then
-      red "ERROR: scons not installed -- please install"
-      exit 1
-    else
-      echo "... scons found in PATH"
-      if ! which python$SCONS_PYTHON_MAJOR > /dev/null 2>&1 ; then
-        red "ERROR: python$SCONS_PYTHON_MAJOR not found in PATH"
-        red "Please install Python $SCONS_PYTHON_MAJOR or higher"
-        exit 1
-      fi
-      echo "... python$SCONS_PYTHON_MAJOR found in PATH"
-      # Check whether it corresponds to a Python 3.6 or above
-      python$SCONS_PYTHON_MAJOR $(which scons) --file=scons-python-version-test.py
-      echo "... python$SCONS_PYTHON_MAJOR is recent enough"
-    fi
-  fi
-
-  if [[ -z "$EVEREST_SCONS_CACHE_DIR" ]]; then
-    echo "Warning: Scons cache directory not set. Set it?"
-    prompt_yes write_everest_env_dest_file true
-  fi
-
   if is_windows; then
     if [[ $(echo $FSTAR_HOME | cut -c 1 | tr -d '\r\n' ) == "/" ]]; then
       magenta "You are on windows but your FSTAR_HOME is a Cygwin-style path."
@@ -1034,57 +901,6 @@ do_forall ()
     blue "Executing in $r"
     (cd $r && "$@" || red "return code was $?, carrying on anyway")
   done
-}
-
-# OS-independent scons. chdir to $1, then passes $2 to scons.
-# The return status is that of the last command.
-run_scons () {
-  short_dir="$1"
-  shift
-  cmd="$1"
-
-  if is_windows ; then
-    DIR=$(cygpath -w "$(pwd)"/"$short_dir")
-  else
-    DIR="$short_dir"
-  fi
-
-  if is_windows; then
-    # Instead of invoking cmd.exe /c, which would force us to
-    # rely on its flaky semantics for double quotes,
-    # we go through a batch file.
-    THIS_PID=$$
-    # Find an unambiguous file name for our .bat file
-    SCONS_EXECS=0
-    while
-      SCONS_INVOKE_FILE="everest$THIS_PID""scons$SCONS_EXECS"".bat" &&
-      [[ -e "$SCONS_INVOKE_FILE" ]]
-    do
-      SCONS_EXECS=$(($SCONS_EXECS + 1))
-    done
-    # Then create, run and remove the .bat file
-    cat > "$SCONS_INVOKE_FILE" <<EOF
-call $VS_ENV_CMD
-cd "$DIR"
-EOF
-    if command -v scons.bat > /dev/null 2>&1 ; then
-      echo "call scons.bat $cmd $parallel_opt" >> "$SCONS_INVOKE_FILE"
-    else
-      PYDIR=$(cygpath -d $(windows_scons_python_dir))
-      echo "$PYDIR/python.exe $PYDIR/Scripts/scons.py $cmd $parallel_opt" >> "$SCONS_INVOKE_FILE"
-    fi
-    chmod +x "$SCONS_INVOKE_FILE"
-    "./$SCONS_INVOKE_FILE"
-    SCONS_RETCODE=$?
-    rm -f "$SCONS_INVOKE_FILE"
-    return $SCONS_RETCODE
-  else
-    python$SCONS_PYTHON_MAJOR_MINOR $(which scons) -C "$DIR" $cmd $parallel_opt
-  fi
-}
-
-run_hacl_vale_scons () {
-  run_scons hacl-star/vale "--FSTAR-MY-VERSION $1 --FSTAR-EXTRACT"
 }
 
 clean_hacl () {

--- a/scons-python-version-test.py
+++ b/scons-python-version-test.py
@@ -1,3 +1,0 @@
-# Run with: python3 scons -f
-EnsurePythonVersion(3, 6)
-EnsureSConsVersion(3, 0)


### PR DESCRIPTION
As far as I know, we no longer need SCons to build Everest. As such, I would like to remove all of the checks and logic in the everest script.
- This will relax a lot of the python checks we currently have in place
- This will make installation easier on fresh systems: our dockerfiles have to use a custom ppa for python 3.6, and the hardlink from /usr/bin/python3 to python3.6 is likely going to cause issues as time goes by and python3.6 becomes more and more outdated

Tahina and Chris, can you tell me what you think? Thanks!