### PR TITLE
repositories.sh: point to new Pulse repo

### DIFF
--- a/repositories.sh
+++ b/repositories.sh
@@ -25,8 +25,8 @@ https[mitls-fstar]=https://github.com/project-everest/mitls-fstar.git
 repositories[MLCrypto]=git@github.com:project-everest/MLCrypto.git
 https[MLCrypto]=https://github.com/project-everest/MLCrypto.git
 
-repositories[pulse]=git@github.com:tahina-pro/pulse-20240207
-https[pulse]=https://github.com/tahina-pro/pulse-20240207
+repositories[pulse]=git@github.com:FStarLang/pulse
+https[pulse]=https://github.com/FStarLang/pulse
 
 repositories[everquic-crypto]=git@github.com:project-everest/everquic-crypto.git
 https[everquic-crypto]=https://github.com/project-everest/everquic-crypto.git


### PR DESCRIPTION
Notably, this is not a functional change as this pulse-20240207 repo was moved into FStarLang and renamed pulse, so the old URL will resolve to this new one, but that's probably only temporary and unclear.