### PR TITLE
everest: bootstrap F*, now required for building Pulse

### DIFF
--- a/everest
+++ b/everest
@@ -951,7 +951,8 @@ set_openssl () {
 }
 
 build_fstar () {
-  $MAKE -C FStar $make_opts
+  $MAKE -C FStar $make_opts fstar
+  $MAKE -C FStar $make_opts bootstrap
 }
 
 build_karamel () {


### PR DESCRIPTION
Pulse relies on checked files for internal compiler modules, after https://github.com/FStarLang/pulse/pull/246.

We use to avoid this need by keeping an OCaml snapshot of the checker in the Pulse repo, but we've removed that since. That was not ideal due to merge conflicts and etc, but also meant that an everest build would not check that Pulse can successfully build.

This changes the F* build rule to add the bootstrapping step.

--

This means an everest build will now be a bit slower. I am also wondering if we still want Pulse in the everest set of projects.

cc @tahina-pro @gebner @msprotz 