### PR TITLE
ci: do not set OTHERFLAGS=--use_hints

### DIFF
--- a/.docker/build/build.sh
+++ b/.docker/build/build.sh
@@ -91,7 +91,6 @@ function exec_build() {
 
 # Some environment variables we want
 export OCAMLRUNPARAM=b
-export OTHERFLAGS="--use_hints"
 export MAKEFLAGS="$MAKEFLAGS -Otarget"
 export V=1 # Verbose F* build
 

--- a/.docker/build/everest-move.sh
+++ b/.docker/build/everest-move.sh
@@ -10,7 +10,6 @@ build_home="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 # Some environment variables we want
 export OCAMLRUNPARAM=b
-export OTHERFLAGS="--use_hints"
 export MAKEFLAGS="$MAKEFLAGS -Otarget"
 export V=1 # Verbose F* build
 


### PR DESCRIPTION
Projects with hints should set the flag, and projects that do not use hints (like F*) must not have this flag set. Otherwise it can change the behavior of warnings and error messages, which we test for.