### PR TITLE
Use OCaml 5.3.0, fix Pulse test (by skipping it)

### DIFF
--- a/.docker/build/linux/Dockerfile.OCaml
+++ b/.docker/build/linux/Dockerfile.OCaml
@@ -35,7 +35,7 @@ RUN wget https://download.visualstudio.microsoft.com/download/pr/cd0d0a4d-2a6a-4
 
 # Install OCaml
 ENV OPAMYES 1
-ARG OCAML_VERSION=4.14.0
+ARG OCAML_VERSION=5.3.0
 RUN opam init --compiler=$OCAML_VERSION --disable-sandboxing 
 
 # Add Everest files and projects

--- a/.docker/build/linux/Dockerfile.everest-move
+++ b/.docker/build/linux/Dockerfile.everest-move
@@ -38,7 +38,7 @@ RUN wget https://download.visualstudio.microsoft.com/download/pr/cd0d0a4d-2a6a-4
 
 # Install OCaml
 ENV OPAMYES 1
-ARG OCAML_VERSION=4.14.0
+ARG OCAML_VERSION=5.3.0
 RUN opam init --compiler=$OCAML_VERSION --disable-sandboxing 
 
 # Add Everest files and projects

--- a/everest
+++ b/everest
@@ -1046,12 +1046,7 @@ do_make ()
 }
 
 test_FStar () {
-  # Migration for https://github.com/FStarLang/FStar/pull/3637
-  if [ -d FStar/stage0 ]; then
-    $MAKE -C FStar $make_opts test
-  else
-    $MAKE -C FStar $make_opts ci-uregressions
-  fi
+  $MAKE -C FStar $make_opts test
 }
 
 test_karamel () {

--- a/everest
+++ b/everest
@@ -1053,7 +1053,7 @@ test_karamel () {
   LD_LIBRARY_PATH= $MAKE -C karamel/test $make_opts everything
 }
 test_pulse () {
-  $MAKE -C pulse test $make_opts PULSE_NO_RUST=1
+  $MAKE -C pulse test $make_opts PULSE_NO_RUST=1 PULSE_NO_DOMAINSLIB=1
 }
 test_steel () {
   $MAKE -C steel test $make_opts


### PR DESCRIPTION
F* and check world are now running OCaml 5.3.0 (though we support older versions too). Pulse in particular added a test that uses domainslib, and that failed during the everest upgrade due to now having the package installed. I'm here passing a flag to skip that test (this will fail until https://github.com/FStarLang/pulse/pull/440 is merged), but also bumping the OCaml version to 5.3.0.

If staying on an older OCaml is preferable that patch can be reverted.