### PR TITLE
docker: bump to Ubuntu 24.10

### DIFF
--- a/.docker/build/linux/Dockerfile.OCaml
+++ b/.docker/build/linux/Dockerfile.OCaml
@@ -5,10 +5,9 @@
 FROM ubuntu:24.10
 
 # Install the dependencies of Project Everest
-# libicu (for .NET, cf. https://aka.ms/dotnet-missing-libicu )
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get --yes install --no-install-recommends opam gcc binutils make m4 git time gnupg ca-certificates sudo cmake curl wget libicu70 libssl-dev python-is-python3 python3 rust-all
+RUN apt-get --yes install --no-install-recommends opam gcc binutils make m4 git time gnupg ca-certificates sudo cmake curl wget libssl-dev python-is-python3 python3 rust-all
 
 # Install NodeJS 16
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -

--- a/.docker/build/linux/Dockerfile.OCaml
+++ b/.docker/build/linux/Dockerfile.OCaml
@@ -2,7 +2,7 @@
 # It must be loaded from the everest repository root
 # (NOT from the directory that contains the Dockerfile)
 
-FROM ubuntu:22.04
+FROM ubuntu:24.10
 
 # Install the dependencies of Project Everest
 # libicu (for .NET, cf. https://aka.ms/dotnet-missing-libicu )

--- a/.docker/build/linux/Dockerfile.everest-move
+++ b/.docker/build/linux/Dockerfile.everest-move
@@ -8,10 +8,9 @@
 FROM ubuntu:24.10
 
 # Install the dependencies of Project Everest
-# libicu (for .NET, cf. https://aka.ms/dotnet-missing-libicu )
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get --yes install --no-install-recommends opam emacs gcc binutils make m4 git time gnupg ca-certificates sudo python-is-python3 python3 cmake curl libicu70 wget libssl-dev rust-all
+RUN apt-get --yes install --no-install-recommends opam emacs gcc binutils make m4 git time gnupg ca-certificates sudo python-is-python3 python3 cmake curl wget libssl-dev rust-all
 
 # Install NodeJS 16
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -

--- a/.docker/build/linux/Dockerfile.everest-move
+++ b/.docker/build/linux/Dockerfile.everest-move
@@ -5,7 +5,7 @@
 # TODO: Ideally, this should be doable with Dockerfile.OCaml
 # To do so, we need to move the everest-move rule into the Everest script.
 
-FROM ubuntu:22.04
+FROM ubuntu:24.10
 
 # Install the dependencies of Project Everest
 # libicu (for .NET, cf. https://aka.ms/dotnet-missing-libicu )

--- a/hashes.sh
+++ b/hashes.sh
@@ -1,14 +1,14 @@
 declare -A hashes
 declare -A branches
-hashes[everparse]=5c929916ab2cc64b938598de449ad9812ebba526
+hashes[everparse]=2b0899825398373f79565e16848188e863c5dbef
 branches[everparse]=master
 hashes[everquic-crypto]=da57244848d6ac66031163db28ddc18ec630493f
 branches[everquic-crypto]=master
-hashes[FStar]=45f7bc40308997fff928963981d614be8e41a141
+hashes[FStar]=d8087b63e287ebd3194b5d13bc40c45cbe947d0a
 branches[FStar]=master
-hashes[hacl-star]=b75b1a44f4663b369209f93fb6b5744b3a6a709b
+hashes[hacl-star]=afeb4de23ff04699bcd0cd00cb8873210bc9cc7b
 branches[hacl-star]=main
-hashes[karamel]=ee8cab3051eda2a50558dab36cc8860addc80126
+hashes[karamel]=c56e0932f05c89c8c68089d909ad9c195f44a02c
 branches[karamel]=master
 hashes[merkle-tree]=4cfeff47084c12d5543d2b1fc724dd9f5d3624ca
 branches[merkle-tree]=main
@@ -16,7 +16,7 @@ hashes[mitls-fstar]=7b7e79d075a615828afcf1e64e16d8a7b0b086c9
 branches[mitls-fstar]=master
 hashes[MLCrypto]=190250bbb8f16e7c3f6a8d443b13600ada4fbe79
 branches[MLCrypto]=master
-hashes[pulse]=c39fc22d1b647ea56bf145f5befdacc45066b222
+hashes[pulse]=05fae854dd3c557a2babeac90cd07a4a3c282563
 branches[pulse]=main
 hashes[steel]=97acce443442a0e9a5f3f298124377a1b143f075
 branches[steel]=main


### PR DESCRIPTION
And advance all hashes manually, to see if this builds everparse properly. If that does not work, I think we should disable the building of COSE in the default everparse rule (COSE is not a component of everparse, it's an example).