### PR TITLE
Introduce `everest env`

### DIFF
--- a/everest
+++ b/everest
@@ -106,7 +106,7 @@ check_no_archive () {
 }
 
 # "Modularity": include other files (requires us to be in the right directory)
-source lib.sh
+source lib.sh           # defines the 'quiet' variable
 source repositories.sh
 source hashes.sh
 
@@ -951,6 +951,17 @@ setup_env () {
   exp PATH
 }
 
+print_env () {
+  setup_env
+  exp () {
+    for v; do
+      echo "$v='${!v}'; export $v;"
+    done
+  }
+  exp FSTAR_EXE FSTAR_HOME VALE_HOME KRML_HOME PULSE_HOME STEEL_HOME HACL_HOME
+  exp MLCRYPTO_HOME EVERPARSE_HOME MITLS_HOME
+}
+
 separator () {
   echo "================================================================================"
 }
@@ -1408,6 +1419,9 @@ COMMAND:
 
   clean     clean all projects
 
+  env       print the relevant environment variables to set, in
+            sourceable format
+
   shell     run a shell with the correct environment variables
 
   help      print the current message
@@ -1594,6 +1608,13 @@ while true; do
       shift
       do_shell "$@"
       # do_shell does not return
+      ;;
+
+    env)
+      quiet=true
+      shift
+      print_env
+      exit 0
       ;;
 
     *)

--- a/lib.sh
+++ b/lib.sh
@@ -1,6 +1,10 @@
 # For pretty output
+quiet=false
+
 color () {
-  if [ -t 1 ]; then
+  if $quiet; then
+    :
+  elif [ -t 1 ]; then
     tput setaf $2 || true
     echo $1
     tput sgr0 || true


### PR DESCRIPTION
This prints the environment variables to set in a sourceable format, similar to opam env and others. There is already `everest shell`, but the subshell will read user dotfiles like `.bash_aliases` and potentially override some of these variables.

```
$ ./everest env

FSTAR_EXE='/home/guido/r/everest/master/FStar/bin/fstar.exe'; export FSTAR_EXE;
FSTAR_HOME='/home/guido/r/everest/master/FStar/'; export FSTAR_HOME;
VALE_HOME='/home/guido/r/everest/master/vale'; export VALE_HOME;
KRML_HOME='/home/guido/r/everest/master/karamel'; export KRML_HOME;
PULSE_HOME='/home/guido/r/everest/master/pulse/out'; export PULSE_HOME;
STEEL_HOME='/home/guido/r/everest/master/steel'; export STEEL_HOME;
HACL_HOME='/home/guido/r/everest/master/hacl-star'; export HACL_HOME;
MLCRYPTO_HOME='/home/guido/r/everest/master/MLCrypto'; export MLCRYPTO_HOME;
EVERPARSE_HOME='/home/guido/r/everest/master/everparse'; export EVERPARSE_HOME;
MITLS_HOME='/home/guido/r/everest/master/mitls-fstar'; export MITLS_HOME;
```

The first line at the beginning is not a problem since it's parsed as a comment :).