### PR TITLE
./everest opam: honor OPAMNODEPEXTS

### DIFF
--- a/everest
+++ b/everest
@@ -243,10 +243,12 @@ find_cygsetup () {
 install_all_opam_packages () {
   packages=$(cat opam-packages | cut -d ' ' -f 2 | tr '\n' ' ')
   opam update
-  if is_windows; then
-    opam install depext-cygwinports || true
+  if ! { [[ "$OPAMNODEPEXTS" = 1 ]] || [[ "$OPAMNODEPEXTS" = yes ]] || [[ "$OPAMNODEPEXTS" = true ]] ; } ; then
+      if is_windows; then
+	  opam install depext-cygwinports || true
+      fi
+      opam depext $packages || true
   fi
-  opam depext $packages || true
   opam install -j 4 $packages
 }
 


### PR DESCRIPTION
this is necessary for users who only want a local install without systemwide changes
