### PR TITLE
Manual advance to pinned HACL* state, tweak CI

### DIFF
--- a/.docker/build/linux/Dockerfile.OCaml
+++ b/.docker/build/linux/Dockerfile.OCaml
@@ -7,7 +7,7 @@ FROM ubuntu:24.04
 # Install the dependencies of Project Everest
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get --yes install --no-install-recommends opam gcc binutils make m4 git time gnupg ca-certificates sudo cmake curl wget libssl-dev python-is-python3 python3 rust-all
+RUN apt-get --yes install --no-install-recommends opam gcc binutils make m4 git time gnupg ca-certificates sudo cmake curl wget libssl-dev python-is-python3 python3 rust-all clang
 RUN apt install -y python3.12-venv # For Everparse testing
 
 # Install NodeJS 16

--- a/.docker/build/linux/Dockerfile.everest-move
+++ b/.docker/build/linux/Dockerfile.everest-move
@@ -10,7 +10,7 @@ FROM ubuntu:24.04
 # Install the dependencies of Project Everest
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update
-RUN apt-get --yes install --no-install-recommends opam emacs gcc binutils make m4 git time gnupg ca-certificates sudo python-is-python3 python3 cmake curl wget libssl-dev rust-all
+RUN apt-get --yes install --no-install-recommends opam emacs gcc binutils make m4 git time gnupg ca-certificates sudo python-is-python3 python3 cmake curl wget libssl-dev rust-all clang
 RUN apt install -y python3.12-venv # For Everparse testing
 
 # Install NodeJS 16

--- a/.github/workflows/linux-x64-upgrade.yaml
+++ b/.github/workflows/linux-x64-upgrade.yaml
@@ -1,8 +1,10 @@
 name: Upgrade Everest
 on:
   workflow_dispatch:
-  schedule:
-    - cron: '1 4,10,16,22 * * *'
+  # This is disabled since ACL* is using a pinned F* version,
+  # and upgrades will almost surely fail.
+  # schedule:
+  #   - cron: '1 4,10,16,22 * * *'
 jobs:
   build:
     runs-on: [self-hosted, linux, X64]

--- a/.github/workflows/linux-x64.yaml
+++ b/.github/workflows/linux-x64.yaml
@@ -5,6 +5,8 @@ on:
     - _**
   pull_request:
   workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * TUE' # every tuesday 4am
 jobs:
   build:
     runs-on: [self-hosted, linux, X64]

--- a/hashes.sh
+++ b/hashes.sh
@@ -1,14 +1,14 @@
 declare -A hashes
 declare -A branches
-hashes[everparse]=e82a15b42dfbd041658989a7211be4dca7746bc5
+hashes[everparse]=b42e1dbe5396dd535649effe195d21b9e505c071
 branches[everparse]=master
 hashes[everquic-crypto]=a075f1b396817281203215f333b94849fe632c89
 branches[everquic-crypto]=master
-hashes[FStar]=5d9a94ff4d58eaa52b479457f58916e6551ef544
+hashes[FStar]=7b347386330d0e5a331a220535b6f15288903234
 branches[FStar]=master
-hashes[hacl-star]=531820c1af15cafc2437068fb565fa0b8b431e73
+hashes[hacl-star]=f9f2d201e2f73b8c0aa67166f04c7f547a450e02
 branches[hacl-star]=main
-hashes[karamel]=fb36fecb552c9fb202beb38a6c5a732c3f2cd49f
+hashes[karamel]=5f493441d9324869eaf83d5994bd62f29aa9ee1e
 branches[karamel]=master
 hashes[merkle-tree]=4cfeff47084c12d5543d2b1fc724dd9f5d3624ca
 branches[merkle-tree]=main
@@ -16,7 +16,7 @@ hashes[mitls-fstar]=7b7e79d075a615828afcf1e64e16d8a7b0b086c9
 branches[mitls-fstar]=master
 hashes[MLCrypto]=190250bbb8f16e7c3f6a8d443b13600ada4fbe79
 branches[MLCrypto]=master
-hashes[pulse]=8bf255ff7d2d4e4bb77b84ceb89cfa4c42b9506f
+hashes[pulse]=f51670f4c0117c8614e10c421025d77e1e44940e
 branches[pulse]=main
-hashes[steel]=6e7352ab80b7dd1a873b3136f2e19c67636d07ea
+hashes[steel]=b1e59366a8c464dfcf0e8bc8069f82e69a258f6b
 branches[steel]=main

--- a/opam-packages
+++ b/opam-packages
@@ -18,7 +18,7 @@ hex hex
 ocamlbuild ocamlbuild
 qcheck qcheck
 cppo cppo
-ppxlib ppxlib
+ppxlib ppxlib.0.36.0
 re re
 odoc odoc
 alcotest alcotest


### PR DESCRIPTION
As discussed, HACL* is now pinned to F* version v2025.10.06. This PR manually updates the hashes to this version of F* and HACL* main as of today. Upgrading F* will be problematic, and will almost surely not work automatically, so the upgrade job is disabled. I did add a scheduled normal build once per week, just to detect breakages related to packages or whatever else.